### PR TITLE
reduce image size by introducing server build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,14 @@ RUN go mod download
 
 COPY ./server .
 
+RUN go build -o /exorcist ./cmd/exorcist
+
+
+FROM golang:1.24-alpine AS exorcist
+
 COPY --from=build_web /home/node/app/dist /web
 
-RUN go build -o /exorcist ./cmd/exorcist
+COPY --from=build_server /exorcist /exorcist
 
 EXPOSE ${PORT}
 


### PR DESCRIPTION
Reduce the size of the final image by introducing a server build step and only making the final image with the frontend and the server build binary