### PR TITLE
Feat/media thumbnail endpoint

### DIFF
--- a/apps/server/internal/mock/repository/image/image.go
+++ b/apps/server/internal/mock/repository/image/image.go
@@ -14,7 +14,7 @@ import (
 
 	uuid "github.com/google/uuid"
 	model "github.com/slugger7/exorcist/apps/server/internal/db/exorcist/public/model"
-	imageRepository "github.com/slugger7/exorcist/apps/server/internal/repository/image"
+	models "github.com/slugger7/exorcist/apps/server/internal/models"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -58,10 +58,10 @@ func (mr *MockImageRepositoryMockRecorder) Create(m any) *gomock.Call {
 }
 
 // GetById mocks base method.
-func (m *MockImageRepository) GetById(arg0 uuid.UUID) (*imageRepository.MediaImage, error) {
+func (m *MockImageRepository) GetById(arg0 uuid.UUID) (*models.MediaImage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetById", arg0)
-	ret0, _ := ret[0].(*imageRepository.MediaImage)
+	ret0, _ := ret[0].(*models.MediaImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -73,10 +73,10 @@ func (mr *MockImageRepositoryMockRecorder) GetById(arg0 any) *gomock.Call {
 }
 
 // GetByMediaId mocks base method.
-func (m *MockImageRepository) GetByMediaId(arg0 uuid.UUID) (*imageRepository.MediaImage, error) {
+func (m *MockImageRepository) GetByMediaId(arg0 uuid.UUID) (*models.MediaImage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetByMediaId", arg0)
-	ret0, _ := ret[0].(*imageRepository.MediaImage)
+	ret0, _ := ret[0].(*models.MediaImage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/apps/server/internal/mock/repository/media/media.go
+++ b/apps/server/internal/mock/repository/media/media.go
@@ -223,6 +223,21 @@ func (mr *MockMediaRepositoryMockRecorder) GetRelationsFor(id any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelationsFor", reflect.TypeOf((*MockMediaRepository)(nil).GetRelationsFor), id)
 }
 
+// GetThumbnailFor mocks base method.
+func (m *MockMediaRepository) GetThumbnailFor(id uuid.UUID) (*model.Media, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetThumbnailFor", id)
+	ret0, _ := ret[0].(*model.Media)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetThumbnailFor indicates an expected call of GetThumbnailFor.
+func (mr *MockMediaRepositoryMockRecorder) GetThumbnailFor(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThumbnailFor", reflect.TypeOf((*MockMediaRepository)(nil).GetThumbnailFor), id)
+}
+
 // Relate mocks base method.
 func (m *MockMediaRepository) Relate(arg0 model.MediaRelation) (*model.MediaRelation, error) {
 	m.ctrl.T.Helper()

--- a/apps/server/internal/models/media.go
+++ b/apps/server/internal/models/media.go
@@ -43,3 +43,8 @@ type Media struct {
 	Tags     []model.Tag
 	Chapters []MediaChapter
 }
+
+type MediaImage struct {
+	model.Image
+	model.Media
+}

--- a/apps/server/internal/repository/image/image.go
+++ b/apps/server/internal/repository/image/image.go
@@ -10,18 +10,14 @@ import (
 	"github.com/slugger7/exorcist/apps/server/internal/db/exorcist/public/table"
 	"github.com/slugger7/exorcist/apps/server/internal/environment"
 	errs "github.com/slugger7/exorcist/apps/server/internal/errors"
+	"github.com/slugger7/exorcist/apps/server/internal/models"
 	"github.com/slugger7/exorcist/apps/server/internal/repository/util"
 )
 
-type MediaImage struct {
-	model.Image
-	model.Media
-}
-
 type ImageRepository interface {
 	Create(m *model.Image) (*model.Image, error)
-	GetById(uuid.UUID) (*MediaImage, error)
-	GetByMediaId(uuid.UUID) (*MediaImage, error)
+	GetById(uuid.UUID) (*models.MediaImage, error)
+	GetByMediaId(uuid.UUID) (*models.MediaImage, error)
 }
 
 type imageRepository struct {
@@ -31,7 +27,7 @@ type imageRepository struct {
 }
 
 // GetByMediaId implements IImageRepository.
-func (i *imageRepository) GetByMediaId(id uuid.UUID) (*MediaImage, error) {
+func (i *imageRepository) GetByMediaId(id uuid.UUID) (*models.MediaImage, error) {
 	media := table.Media
 	image := table.Image
 
@@ -45,7 +41,7 @@ func (i *imageRepository) GetByMediaId(id uuid.UUID) (*MediaImage, error) {
 
 	util.DebugCheck(i.env, statement)
 
-	var result MediaImage
+	var result models.MediaImage
 	if err := statement.QueryContext(i.ctx, i.db, &result); err != nil {
 		return nil, errs.BuildError(err, "could not get image by media id: %v", id)
 	}
@@ -89,8 +85,8 @@ func (i *imageRepository) Create(m *model.Image) (*model.Image, error) {
 	return &img, nil
 }
 
-func (i *imageRepository) GetById(id uuid.UUID) (*MediaImage, error) {
-	var img MediaImage
+func (i *imageRepository) GetById(id uuid.UUID) (*models.MediaImage, error) {
+	var img models.MediaImage
 	statement := table.Image.SELECT(table.Image.AllColumns, table.Media.AllColumns).
 		FROM(table.Image.INNER_JOIN(
 			table.Image,

--- a/apps/server/internal/repository/media/media.go
+++ b/apps/server/internal/repository/media/media.go
@@ -35,6 +35,7 @@ type MediaRepository interface {
 	GetAssetsFor(id uuid.UUID) ([]models.MediaRelation, error)
 	GetProgressForUser(id, userId uuid.UUID) (*model.MediaProgress, error)
 	GetRelationsFor(id uuid.UUID) ([]models.MediaRelation, error)
+	GetThumbnailFor(id uuid.UUID) (*model.Media, error)
 
 	UpsertProgress(prog model.MediaProgress) (*model.MediaProgress, error)
 	Update(m model.Media, columns postgres.ColumnList) (*model.Media, error)
@@ -50,6 +51,29 @@ type mediaRepository struct {
 	env    *environment.EnvironmentVariables
 	logger logger.Logger
 	ctx    context.Context
+}
+
+// GetThumbnailFor implements [MediaRepository].
+func (r *mediaRepository) GetThumbnailFor(id uuid.UUID) (*model.Media, error) {
+	statement := media.SELECT(media.AllColumns).
+		FROM(media.INNER_JOIN(table.MediaRelation,
+			table.MediaRelation.RelatedTo.EQ(media.ID).
+				AND(table.MediaRelation.MediaID.EQ(postgres.UUID(id))).
+				AND(table.MediaRelation.RelationType.EQ(postgres.NewEnumValue(model.MediaRelationTypeEnum_Thumbnail.String()))),
+		))
+
+	util.DebugCheck(r.env, statement)
+
+	var entities []model.Media
+	if err := statement.QueryContext(r.ctx, r.db, &entities); err != nil {
+		return nil, errs.BuildError(err, "could not fetch media for: %v", id.String())
+	}
+
+	if len(entities) == 0 {
+		return nil, nil
+	}
+
+	return &entities[0], nil
 }
 
 // GetRelationsFor implements MediaRepository.
@@ -158,7 +182,7 @@ func (r *mediaRepository) GetByLibraryId(libraryId uuid.UUID, pageRequest *dto.P
 
 	var data []model.Media
 	total := 0
-	if mediaResult != nil && len(mediaResult) > 0 {
+	if len(mediaResult) > 0 {
 		data = make([]model.Media, len(mediaResult))
 		total = mediaResult[0].Total
 		for i, o := range mediaResult {

--- a/apps/server/internal/server/image.go
+++ b/apps/server/internal/server/image.go
@@ -9,14 +9,12 @@ import (
 )
 
 func (s *server) withImageGet(r *gin.RouterGroup, route Route) *server {
-	r.GET(fmt.Sprintf("%v/:id", route), s.getImage)
+	r.GET(fmt.Sprintf("%v/:%v", route, idKey), s.getImage)
 	return s
 }
 
 func (s *server) getImage(c *gin.Context) {
-	idString := c.Param("id")
-
-	id, err := uuid.Parse(idString)
+	id, err := uuid.Parse(c.Param(idKey))
 	if err != nil {
 		s.logger.Errorf("Incorrect id format: %v", err.Error())
 		c.JSON(http.StatusBadRequest, gin.H{"error": ErrInvalidIdFormat})

--- a/apps/server/internal/server/media.go
+++ b/apps/server/internal/server/media.go
@@ -52,6 +52,16 @@ func (s *server) withMediaPut(r *gin.RouterGroup, route Route) *server {
 	return s
 }
 
+func (s *server) withMediaThumbnailGet(r *gin.RouterGroup, route Route) *server {
+	r.GET(fmt.Sprintf("%v/:%v/thumbnail", route, idKey), s.getMediaThumbnail)
+
+	return s
+}
+
+func (s *server) getMediaThumbnail(c *gin.Context) {
+	c.Status(http.StatusOK)
+}
+
 func (s *server) putMedia(c *gin.Context) {
 	id, err := uuid.Parse(c.Param(idKey))
 	if err != nil {

--- a/apps/server/internal/server/media.go
+++ b/apps/server/internal/server/media.go
@@ -59,7 +59,26 @@ func (s *server) withMediaThumbnailGet(r *gin.RouterGroup, route Route) *server 
 }
 
 func (s *server) getMediaThumbnail(c *gin.Context) {
-	c.Status(http.StatusOK)
+	id, err := uuid.Parse(c.Param(idKey))
+	if err != nil {
+		c.AbortWithStatusJSON(http.StatusUnprocessableEntity, gin.H{"error": "could not parse media id"})
+		return
+	}
+
+	thumb, err := s.repo.Media().GetThumbnailFor(id)
+	if err != nil {
+		s.logger.Errorf("could not get thumbnail media for: %v\n%v", id, err.Error())
+		c.AbortWithStatus(http.StatusNotFound)
+		return
+	}
+
+	if thumb == nil {
+		s.logger.Warningf("thumbnail not found for media: :%v", id)
+		c.AbortWithStatus(http.StatusNotFound)
+		return
+	}
+
+	c.File(thumb.Path)
 }
 
 func (s *server) putMedia(c *gin.Context) {

--- a/apps/server/internal/server/routes.go
+++ b/apps/server/internal/server/routes.go
@@ -78,7 +78,8 @@ func (s *server) RegisterRoutes() http.Handler {
 		withMediaPutPerson(authenticated, mediaRoute).
 		withMediaDeletePerson(authenticated, mediaRoute).
 		withMediaDelete(authenticated, mediaRoute).
-		withMediaPut(authenticated, mediaRoute)
+		withMediaPut(authenticated, mediaRoute).
+		withMediaThumbnailGet(authenticated, mediaRoute)
 
 	s.withImageGet(authenticated, images).
 		withVideoGet(authenticated, videos).

--- a/apps/server/rest/job.http
+++ b/apps/server/rest/job.http
@@ -7,7 +7,7 @@ Content-Type: application/json
 
 {
   "type": "scan_path",
-  "data": {"libraryPathId":"cecfbcb0-f7ee-4dc9-b83b-86a3f009203e"}
+  "data": {"libraryPathId":"da4c5635-75cf-4b5b-811e-7361caeea1c8"}
 }
 
 ### Create generate thumbnail job

--- a/apps/server/rest/media.http
+++ b/apps/server/rest/media.http
@@ -1,5 +1,5 @@
 ### Get All videos
-GET {{host}}:{{port}}/api/media?limit=50&favourites=true
+GET {{host}}:{{port}}/api/media?limit=50&favourites=false
 
 ### Get media by id
 GET {{host}}:{{port}}/api/media/0fa21151-458f-4a33-aa89-3e374952ddd8
@@ -56,4 +56,4 @@ Content-Type: application/json
 }
 
 ### Get Thumbnail
-GET {{host}}:{{port}}/api/media/0fa21151-458f-4a33-aa89-3e374952ddd8/thumbnail
+GET {{host}}:{{port}}/api/media/b8a94e24-3b5e-485e-87e4-2bd30740bf50/thumbnail

--- a/apps/server/rest/media.http
+++ b/apps/server/rest/media.http
@@ -54,3 +54,6 @@ Content-Type: application/json
 {
   "title": "Updated title"
 }
+
+### Get Thumbnail
+GET {{host}}:{{port}}/api/media/0fa21151-458f-4a33-aa89-3e374952ddd8/thumbnail

--- a/apps/web/src/lib/components/VideoCard.svelte
+++ b/apps/web/src/lib/components/VideoCard.svelte
@@ -1,7 +1,7 @@
 <script>
   import { Link } from "svelte-routing";
   import routes from "../../routes/routes";
-  import { imageUrlById } from "../controllers/image";
+  import { imageUrlById, thumbnailUrl } from "../controllers/image";
 
   /** @import { MediaOverviewDTO } from "../types"*/
 
@@ -42,7 +42,7 @@
     <button class={`button ${selected ? "is-focused" : ""}`} onclick={onselect}
       ><img
         class="image"
-        src={imageUrlById(video.thumbnailId)}
+        src={thumbnailUrl(video.id)}
         alt={video.title}
       /></button
     >
@@ -50,7 +50,7 @@
     <Link to={routes.videoFunc(video.id, video.title)}
       ><img
         class="image"
-        src={imageUrlById(video.thumbnailId)}
+        src={thumbnailUrl(video.id)}
         alt={video.title}
       /></Link
     >

--- a/apps/web/src/lib/controllers/image.js
+++ b/apps/web/src/lib/controllers/image.js
@@ -5,3 +5,9 @@ import { server } from "../env";
  * @returns {string}
  */
 export const imageUrlById = (id) => `${server()}/images/${id}`
+
+/**
+ * @param {string} mediaId
+ * @returns {string}
+ */
+export const thumbnailUrl = (mediaId) => `${server()}/media/${mediaId}/thumbnail`


### PR DESCRIPTION
Creates a new endpoint to use the media's id to get its thumbnail.

It also swaps out the use of the image endpoint for the thumbnail endpoint instead