### PR TITLE
Fix/page rerender on select

### DIFF
--- a/apps/web/src/lib/components/Items.svelte
+++ b/apps/web/src/lib/components/Items.svelte
@@ -2,6 +2,7 @@
   import ItemSelector from "./ItemSelector.svelte";
   import HeaderIconButton from "./HeaderIconButton.svelte";
   import { Link } from "svelte-routing";
+  import { pageState } from "../state/pageState.svelte";
   /**
    * @import { Item, FetchItems, RemoveItem, AddItem, CreateItem, ItemUrlFn } from '../types'
    *
@@ -31,6 +32,7 @@
   let editing = $state(false);
   /** @type {Item[]} */
   let selectedItems = $state([]);
+  /** @type {Item[]}*/
   let allItems = $state([]);
   let loadingItems = $state(false);
 
@@ -76,6 +78,7 @@
     addItem(item);
   };
 
+  /** @param {Item} item */
   const addItem = async (item) => {
     selectedItems.push(item);
 
@@ -150,8 +153,10 @@
     {#each selectedItems as item}
       <div class="control">
         <div class="tags has-addons is-medium">
-          <Link class="tag is-link" to={urlFn(item.id, item.name)}
-            >{item.name}</Link
+          <Link
+            class="tag is-link"
+            to={urlFn(item.id, item.name)}
+            on:click={(_e) => (pageState.id = item.id)}>{item.name}</Link
           >
           {#if editing}
             <button

--- a/apps/web/src/lib/components/MediaView.svelte
+++ b/apps/web/src/lib/components/MediaView.svelte
@@ -56,22 +56,22 @@
   let ascending = $state(getBoolParamOrDefault("ascending", false));
   let selectedTags = $state(getArrayOfStringsSearchParamOrDefault("tags", []));
   let selectedWatchStatuses = $state(
-    getArrayOfStringsSearchParamOrDefault("watchStatuses", [])
+    getArrayOfStringsSearchParamOrDefault("watchStatuses", []),
   );
   let selectedPeople = $state(
-    getArrayOfStringsSearchParamOrDefault("people", [])
+    getArrayOfStringsSearchParamOrDefault("people", []),
   );
   let expanded = $state(getBoolParamOrDefault("expanded", false));
   let selecting = $state(getBoolParamOrDefault("selecting", false));
   let selectedMedia = $state(
-    getArrayOfStringsSearchParamOrDefault("selected", [])
+    getArrayOfStringsSearchParamOrDefault("selected", []),
   );
   let favourites = $state(getBoolParamOrDefault("favourites", false));
   let deleted = $state(getBoolParamOrDefault("deleted", false));
   let exists = $state(getBoolParamOrDefault("exists", true));
   let loading = $state(false);
   let error = $state();
-  /** @type {PageDTO<MediaOverviewDTO>}*/
+  /** @type {PageDTO<MediaOverviewDTO> | undefined}*/
   let mediaPage = $state();
   /** @type {MediaOverviewDTO[]}*/
   let newMedia = $state([]);
@@ -236,11 +236,11 @@
     const data = JSON.parse(e.data);
 
     const topic = topicMap[data.topic];
-    if (topic) {
+    if (topic && mediaPage) {
       const [updatedMediaPage, updatedNewMedia] = topic(
         mediaPage,
         newMedia,
-        data.data
+        data.data,
       );
       mediaPage = updatedMediaPage;
       newMedia = updatedNewMedia;
@@ -255,12 +255,16 @@
     setValueAndNavigate("search", search, route, { replace: true });
   };
 
+  /** @type {number}*/
   let searchTimeout;
+  /** @param {Event} event */
   const onSearchChange = (event) => {
     clearTimeout(searchTimeout);
     searchTimeout = setTimeout(() => {
+      // @ts-ignore
       setSearchAndNavigate(event.target.value);
 
+      // @ts-ignore
       event.target.focus();
     }, 500);
   };
@@ -269,6 +273,7 @@
     setSearchAndNavigate("");
   };
 
+  /** @param {string} id*/
   const toggleMediaSelected = (id) => () => {
     const exists = !!selectedMedia.find((m) => m === id);
     if (exists) {
@@ -286,7 +291,9 @@
         value={title}
         loading={submittingTitle}
         onsave={async (e, updatedTitle) => {
-          await updateTitle(updatedTitle);
+          if (updateTitle) {
+            await updateTitle(updatedTitle);
+          }
 
           editingTitle = false;
         }}

--- a/apps/web/src/lib/controllers/media.js
+++ b/apps/web/src/lib/controllers/media.js
@@ -59,7 +59,7 @@ export const get = async (id) => {
 /**
  * @param {string} id
  * @param {boolean} [physical]
- * @returns {Promise}
+ * @returns {Promise<undefined>}
  */
 export const deleteMedia = async (id, physical = false) => {
   const params = new URLSearchParams()

--- a/apps/web/src/lib/searchParams.js
+++ b/apps/web/src/lib/searchParams.js
@@ -1,13 +1,17 @@
 import { navigate } from "svelte-routing";
 
 /**
-  * @param {string} param
+  * @param {string} key
   * @param {number} def
   * @returns {number}
   */
-export const getIntSearchParamOrDefault = (param, def) => {
+export const getIntSearchParamOrDefault = (key, def) => {
   const params = new URLSearchParams(window.location.search);
-  const val = parseInt(params.get(param));
+  const param = params.get(key)
+  if (!param) {
+    return def
+  }
+  const val = parseInt(param);
   if (isNaN(val)) {
     return def;
   }

--- a/apps/web/src/lib/state/pageState.svelte.js
+++ b/apps/web/src/lib/state/pageState.svelte.js
@@ -1,0 +1,4 @@
+export let pageState = $state({
+  /** @type {string | undefined} */
+  id: undefined
+})

--- a/apps/web/src/routes/GenerateChaptersJob.svelte
+++ b/apps/web/src/routes/GenerateChaptersJob.svelte
@@ -49,7 +49,6 @@
           class="input"
           name="interval"
           type="number"
-          autofocus
           bind:value={interval}
         />
       </div>

--- a/apps/web/src/routes/GenerateThumbnailJob.svelte
+++ b/apps/web/src/routes/GenerateThumbnailJob.svelte
@@ -47,7 +47,6 @@
           class="input"
           name="timestamp"
           type="number"
-          autofocus
           bind:value={timestamp}
         />
       </div>

--- a/apps/web/src/routes/Person.svelte
+++ b/apps/web/src/routes/Person.svelte
@@ -4,11 +4,21 @@
   import { ordinals } from "../lib/controllers/media";
   import { getMediaWithParams, updatePerson } from "../lib/controllers/people";
   import { navigate } from "svelte-routing";
+  import { pageState } from "../lib/state/pageState.svelte";
+  import { onMount } from "svelte";
 
-  let { id, name } = $props();
+  let { id: paramId, name } = $props();
   let title = $state(name);
   let submittingTitle = $state(false);
+  let id = $derived(pageState.id ? pageState.id : paramId);
 
+  onMount(() => {
+    if (pageState.id === undefined) {
+      pageState.id = paramId;
+    }
+  });
+
+  /** @param {string} newTitle */
   const updateTitle = async (newTitle) => {
     submittingTitle = true;
     try {

--- a/apps/web/src/routes/Routes.svelte
+++ b/apps/web/src/routes/Routes.svelte
@@ -82,15 +82,9 @@
         /></Route
     >
     <Route path={routes.generateChapters} let:params
-        ><GenerateChaptersJob
-            mediaId={params.id}
-            redirect={params.redirect}
-        /></Route
+        ><GenerateChaptersJob mediaId={params.id} /></Route
     >
     <Route path={routes.generateThumbnail} let:params
-        ><GenerateThumbnailJob
-            mediaId={params.id}
-            redirect={params.redirect}
-        /></Route
+        ><GenerateThumbnailJob mediaId={params.id} /></Route
     >
 </main>

--- a/apps/web/src/routes/Tag.svelte
+++ b/apps/web/src/routes/Tag.svelte
@@ -4,11 +4,21 @@
   import { ordinals } from "../lib/controllers/media";
   import { getMediaWithParams, updateTag } from "../lib/controllers/tags";
   import { navigate } from "svelte-routing";
+  import { pageState } from "../lib/state/pageState.svelte";
+  import { onMount } from "svelte";
 
-  let { id, name } = $props();
+  let { id: paramId, name } = $props();
   let title = $state(name);
   let submittingTitle = $state(false);
+  let id = $derived(pageState.id ? pageState.id : paramId);
 
+  onMount(() => {
+    if (pageState.id === undefined) {
+      pageState.id = paramId;
+    }
+  });
+
+  /** @param {string} newTitle*/
   const updateTitle = async (newTitle) => {
     submittingTitle = true;
     try {

--- a/apps/web/src/routes/routes.js
+++ b/apps/web/src/routes/routes.js
@@ -45,13 +45,23 @@ const routes = {
         return `/playlists-add?${params.toString()}`
     },
     refreshMetadata: "/jobs/refresh-metadata/media/:id/:redirect",
+    /**
+     * @param {string} id
+     * @param {string} redirect
+     */
     refreshMetadataFn: (id, redirect) => (`/jobs/refresh-metadata/media/${id}/${encodeURIComponent(redirect)}`),
     refreshLibraryMetadata: "/jobs/refresh-metadata/library/:id/:redirect",
+    /**
+     * @param {string} id
+     * @param {string} redirect
+     */
     refreshLibraryMetadataFn: (id, redirect) => (`/jobs/refresh-metadata/library/${id}/${encodeURIComponent(redirect)}`),
-    generateChapters: "/jobs/generate-chapters/media/:id/:redirect",
-    generateChaptersFn: (id, redirect) => (`/jobs/generate-chapters/media/${id}/${encodeURIComponent(redirect)}`),
-    generateThumbnail: "/jobs/generate-thumbnail/media/:id/:redirect",
-    generateThumbnailFn: (id, redirect) => (`/jobs/generate-thumbnail/media/${id}/${encodeURIComponent(redirect)}`),
+    generateChapters: "/jobs/generate-chapters/media/:id/",
+    /** @param {string} id */
+    generateChaptersFn: (id) => (`/jobs/generate-chapters/media/${id}`),
+    generateThumbnail: "/jobs/generate-thumbnail/media/:id/",
+    /** @param {string} id */
+    generateThumbnailFn: (id) => (`/jobs/generate-thumbnail/media/${id}`),
     create: {
         library: "/create/libraries",
         /** @type {ItemUrlFn} */


### PR DESCRIPTION
There was an issue where on Tag and Person view if you are selecting that the page would rerender the whole time everytime a selection changes.

It seems to have been that the fetch function relies on the path parameter for the id and everytime a selection changes it navigates to the new page with the selection in the path rerendering the entie page.

This PR fixes this by letting the component first rely on shared state set before redirecting to the page and defaulting to the parameter in the path if the state does not exist